### PR TITLE
Add requirements.txt with project dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp
+pydantic


### PR DESCRIPTION
## Summary
- add requirements.txt listing fastmcp and pydantic dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastmcp)*

------
https://chatgpt.com/codex/tasks/task_e_68b68ef19af0832b91d8fa4992dfe6f9