### PR TITLE
fix: update Field regex to pattern for Pydantic v2

### DIFF
--- a/alert_tools.py
+++ b/alert_tools.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field
 from server_main import app
 
 class AlertRaiseParams(BaseModel):
-    level: str = Field(..., regex=r"^(info|warning|critical)$")
+    level: str = Field(..., pattern=r"^(info|warning|critical)$")
     message: str
     zone_id: str | None = None
     target_id: str | None = None


### PR DESCRIPTION
## Summary
- replace deprecated `regex` arg in `Field` with `pattern` for Pydantic v2
- run `python -m py_compile` to ensure modules compile

## Testing
- `python -m py_compile alert_tools.py eots_tools.py server_main.py system_tools.py target_tools.py zone_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b5a121b8832bb8ebe4fd82bab32c