### PR TITLE
Handle FastMCP without run_http

### DIFF
--- a/server_main.py
+++ b/server_main.py
@@ -23,6 +23,12 @@ if __name__ == "__main__":
     # 코랩은 외부 포트 접근이 어려워 STDIO 권장
     USE_HTTP = True  # ← 코랩에서는 False
     if USE_HTTP:
-        app.run_http(host="0.0.0.0", port=8765)
+        if hasattr(app, "run_http"):
+            app.run_http(host="0.0.0.0", port=8765)
+        else:
+            app.run(host="0.0.0.0", port=8765)
     else:
-        app.run_stdio()
+        if hasattr(app, "run_stdio"):
+            app.run_stdio()
+        else:
+            app.run()


### PR DESCRIPTION
## Summary
- add compatibility logic for FastMCP versions lacking `run_http`

## Testing
- `python -m py_compile server_main.py`
- `python server_main.py` *(fails: ModuleNotFoundError: No module named 'fastmcp')*


------
https://chatgpt.com/codex/tasks/task_e_68b6cd1a6d80832b865933acc863fa8b